### PR TITLE
Add index to improve dashboard query performance

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -258,6 +258,8 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.7.0)
+    nokogiri (1.15.3-aarch64-linux)
+      racc (~> 1.4)
     nokogiri (1.15.3-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.15.3-x86_64-linux)
@@ -490,6 +492,7 @@ GEM
     zeitwerk (2.6.8)
 
 PLATFORMS
+  aarch64-linux
   x86_64-darwin-18
   x86_64-linux
 

--- a/db/migrate/20241211042837_add_index_to_visit_date_in_visits.rb
+++ b/db/migrate/20241211042837_add_index_to_visit_date_in_visits.rb
@@ -1,0 +1,5 @@
+class AddIndexToVisitDateInVisits < ActiveRecord::Migration[7.0]
+  def change
+    add_index :visits, :visit_date, if_not_exists: true
+  end
+end

--- a/db/migrate/20241211043033_add_index_to_app_user_characteristics.rb
+++ b/db/migrate/20241211043033_add_index_to_app_user_characteristics.rb
@@ -1,0 +1,5 @@
+class AddIndexToAppUserCharacteristics < ActiveRecord::Migration[7.0]
+  def change
+    add_index :app_user_characteristics, [:app_user_id, :characteristic_id], name: "index_app_user_characteristics_on_app_user_id_and_char_id", if_not_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_15_223535) do
+ActiveRecord::Schema[7.0].define(version: 2024_12_11_043033) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -32,6 +32,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_15_223535) do
     t.uuid "characteristic_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["app_user_id", "characteristic_id"], name: "index_app_user_characteristics_on_app_user_id_and_char_id"
   end
 
   create_table "app_user_reasons", force: :cascade do |t|
@@ -550,6 +551,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_15_223535) do
     t.uuid "app_user_id"
     t.uuid "pageable_id"
     t.integer "pageable_type"
+    t.index ["visit_date"], name: "index_visits_on_visit_date"
   end
 
   create_table "working_days", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION
To improve query performance, we
- add index to visits on visit_date
- add index to app_user_characteristics on [:app_user_id, :characteristic_id]