### PR TITLE
Mobile notification: Set token to inactive when notify error

### DIFF
--- a/app/models/mobile_token.rb
+++ b/app/models/mobile_token.rb
@@ -11,6 +11,7 @@
 #  updated_at  :datetime         not null
 #  platform    :integer          default("android")
 #  device_os   :string
+#  active      :boolean          default(TRUE)
 #
 class MobileToken < ApplicationRecord
   # Association
@@ -21,6 +22,9 @@ class MobileToken < ApplicationRecord
   validates :device_id, presence: true
   validates :device_type, presence: true
   validates :app_version, presence: true
+
+  # Scope
+  scope :actives, -> { where(active: true) }
 
   # Enum
   enum platform: {

--- a/config/initializers/rack-attack.rb
+++ b/config/initializers/rack-attack.rb
@@ -35,7 +35,7 @@ Rack::Attack.throttle("req/ip", limit: ENV.fetch("THROTTLE_REQUEST_LIMIT") { 5 }
   req.ip
 end
 
-Rack::Attack.throttled_response = lambda do |env|
+Rack::Attack.throttled_responder = lambda do |env|
   # Using 503 because it may make attacker think that they have successfully
   # DOSed the site. Rack::Attack returns 429 for throttling by default
   [ 503, {}, ["Internal Server Error"]]

--- a/db/migrate/20250222031103_add_active_to_mobile_tokens.rb
+++ b/db/migrate/20250222031103_add_active_to_mobile_tokens.rb
@@ -1,0 +1,5 @@
+class AddActiveToMobileTokens < ActiveRecord::Migration[7.0]
+  def change
+    add_column :mobile_tokens, :active, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_12_11_043033) do
+ActiveRecord::Schema[7.0].define(version: 2025_02_22_031103) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -279,6 +279,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_12_11_043033) do
     t.datetime "updated_at", null: false
     t.integer "platform", default: 1
     t.string "device_os"
+    t.boolean "active", default: true
   end
 
   create_table "oauth_access_grants", force: :cascade do |t|

--- a/spec/factories/mobile_tokens.rb
+++ b/spec/factories/mobile_tokens.rb
@@ -11,6 +11,7 @@
 #  updated_at  :datetime         not null
 #  platform    :integer          default("android")
 #  device_os   :string
+#  active      :boolean          default(TRUE)
 #
 FactoryBot.define do
   factory :mobile_token do

--- a/spec/models/mobile_token_spec.rb
+++ b/spec/models/mobile_token_spec.rb
@@ -11,6 +11,7 @@
 #  updated_at  :datetime         not null
 #  platform    :integer          default("android")
 #  device_os   :string
+#  active      :boolean          default(TRUE)
 #
 require "rails_helper"
 

--- a/spec/sidekiq/mobile_notification_job_spec.rb
+++ b/spec/sidekiq/mobile_notification_job_spec.rb
@@ -1,0 +1,84 @@
+require "rails_helper"
+
+RSpec.describe MobileNotificationJob, type: :job do
+  let(:notification) { create(:mobile_notification) }
+  let(:mobile_tokens) { create_list(:mobile_token, 3, platform: notification.platform, active: true) }
+  let(:push_notification_service) { PushNotificationService.new(notification) }
+  let(:result) { { success_count: 2, failure_count: 1, detail: "Some detail" } }
+
+  before do
+    allow(PushNotificationService).to receive(:new).and_return(push_notification_service)
+    allow(push_notification_service).to receive(:notify_all).and_return(result)
+  end
+
+  describe "#perform" do
+    context "when notification exists" do
+      it "finds the notification and processes it" do
+        expect(MobileNotification).to receive(:find_by).with(id: notification.id).and_return(notification)
+        expect(notification).to receive(:update_columns).with(
+          success_count: result[:success_count],
+          failure_count: result[:failure_count],
+          status: :delivered,
+          detail: result[:detail]
+        )
+
+        described_class.new.perform(notification.id)
+      end
+
+      it "calls push_notifications and update_notification methods" do
+        expect_any_instance_of(described_class).to receive(:push_notifications)
+        expect_any_instance_of(described_class).to receive(:update_notification)
+
+        described_class.new.perform(notification.id)
+      end
+    end
+
+    context "when notification does not exist" do
+      it "does not process the notification" do
+        expect(MobileNotification).to receive(:find_by).with(id: 999).and_return(nil)
+        expect_any_instance_of(described_class).not_to receive(:push_notifications)
+        expect_any_instance_of(described_class).not_to receive(:update_notification)
+
+        described_class.new.perform(999)
+      end
+    end
+  end
+
+  describe "#mobile_tokens" do
+    it "returns active mobile tokens for the notification platform" do
+      job = described_class.new
+      job.instance_variable_set(:@notification, notification)
+      mobile_tokens.first.update(active: false)
+
+      expect(job.send(:mobile_tokens).count).to eq(2)
+    end
+  end
+
+  describe "#push_notifications" do
+    it "calls PushNotificationService to notify all mobile tokens" do
+      job = described_class.new
+      job.instance_variable_set(:@notification, notification)
+
+      expect(push_notification_service).to receive(:notify_all).with(mobile_tokens)
+
+      job.send(:push_notifications)
+    end
+  end
+
+  describe "#update_notification" do
+    it "updates the notification with the result of push notifications" do
+      job = described_class.new
+      job.instance_variable_set(:@notification, notification)
+      job.instance_variable_set(:@result, result)
+
+      expect(notification).to receive(:update_columns).with(
+        success_count: result[:success_count],
+        failure_count: result[:failure_count],
+        status: :delivered,
+        detail: result[:detail]
+      )
+
+      job.send(:update_notification)
+    end
+  end
+end


### PR DESCRIPTION
- Add an active column to mobile_tokens.
- Filter active tokens for pushing a notification
- When push fails (status 400, 403, and 404), update the token as inactive.