### PR TITLE
Theme: add name validation max length to 15 characters

### DIFF
--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -29,7 +29,7 @@ class Theme < ApplicationRecord
   has_many :assets, dependent: :destroy
 
   # Validation
-  validates :name, presence: true, uniqueness: true
+  validates :name, presence: true, uniqueness: true, length: { maximum: 15 }
   validates :primary_color, presence: true
   validates :secondary_color, presence: true
   validates :primary_text_color, presence: true

--- a/app/views/themes/_form.html.haml
+++ b/app/views/themes/_form.html.haml
@@ -3,9 +3,9 @@
     = simple_form_for @theme, html: {} do |f|
       .mb-3
         .d-flex
-          = f.label :name, "#{t('theme.name')} <abbr title='required'>*</abbr>".html_safe, class: 'flex-grow-1'
+          = f.label :name, "#{t('theme.name_with_max_length')} <abbr title='required'>*</abbr>".html_safe, class: 'flex-grow-1'
           = create_theme_tip
-        = f.input :name, label: false, disabled: policy(@theme).disable_edit?
+        = f.input :name, label: false, disabled: policy(@theme).disable_edit?, maxlength: 15
       .mb-3
         .d-flex
           = f.label :primary_color, "#{t('theme.primary_color')} <abbr title='required'>*</abbr>".html_safe

--- a/config/locales/theme/en.yml
+++ b/config/locales/theme/en.yml
@@ -3,7 +3,7 @@ en:
     themes: Themes
     theme: Theme
     name: Name
-    description: Description
+    name_with_max_length: Name (maximum 15 characters)
     primary_color: Primary color
     secondary_color: Secondary color
     primary_text_color: Primary text color

--- a/config/locales/theme/km.yml
+++ b/config/locales/theme/km.yml
@@ -3,7 +3,7 @@ km:
     themes: Themes
     theme: Theme
     name: ឈ្មោះ
-    description: បរិយាយ
+    name_with_max_length: ឈ្មោះ (អតិបរិមា 15តួ)
     primary_color: ពណ៌ចម្បង (Primary color)
     secondary_color: ពណ៌បន្ទាប់បន្សំ (Secondary color)
     primary_text_color: ពណ៌អត្ថបទចម្បង (Primary text color)

--- a/spec/factories/themes.rb
+++ b/spec/factories/themes.rb
@@ -17,7 +17,7 @@
 #
 FactoryBot.define do
   factory :theme do
-    name { FFaker::Name.name }
+    name { FFaker::Name.name[0..14] }
     primary_color { "#000" }
     secondary_color { "#fff" }
     primary_text_color { "#000" }

--- a/spec/models/theme_spec.rb
+++ b/spec/models/theme_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe Theme, type: :model do
   describe "validations" do
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_uniqueness_of(:name) }
+    it { is_expected.to validate_length_of(:name).is_at_most(15) }
     it { is_expected.to validate_presence_of(:primary_color) }
     it { is_expected.to validate_presence_of(:secondary_color) }
     it { is_expected.to validate_presence_of(:primary_text_color) }


### PR DESCRIPTION
**Why**
- Want to display theme names in a shorter format so the mobile app can display them nicely.
![2025-03-24 10 25 32](https://github.com/user-attachments/assets/a93fbecd-d177-41be-9d65-671a0f9fc73d)

**How**
- Apply max length to the theme name.

**Screenshot**

<img width="913" alt="Screenshot 2025-03-24 at 10 21 31 AM" src="https://github.com/user-attachments/assets/aeb98710-2f2d-4900-a2a4-6c4f13806a63" />
