### PR TITLE
Github workflow file: set ubuntu-22.04 to support ruby 3.1.2

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -12,7 +12,7 @@ on:
     branches: [ "master" ]
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     services:
       postgres:
         image: postgres:11-alpine


### PR DESCRIPTION
**Why**
`runs-on: ubuntu-latest` here uses Ubuntu 24.04.
Ubuntu 24.04 (released in April 2024) is a relatively new operating system as of March 26, 2025. The version of the setup-ruby action we're using (tied to that commit) might not yet support Ubuntu 24.04, as it could have been built before this OS version was widely adopted or officially supported.

**How**
`runs-on: ubuntu-22.04`. Use this version as a `ruby:3.1.2` image built on `ubuntu-22.04`, so this version should work.


