### PR TITLE
Theme: add api for theme usage

### DIFF
--- a/app/controllers/api/v1/theme_usages_controller.rb
+++ b/app/controllers/api/v1/theme_usages_controller.rb
@@ -1,0 +1,22 @@
+module Api
+  module V1
+    class ThemeUsagesController < ApiController
+      def create
+        theme_usage = ThemeUsage.new(theme_usage_params)
+
+        if theme_usage.save
+          render json: theme_usage, status: :created
+        else
+          render json: { errors: theme_usage.errors }, status: :unprocessable_entity
+        end
+      end
+
+      private
+        def theme_usage_params
+          params.require(:theme_usage).permit(
+            :app_user_id, :theme_id, :applied_at
+          )
+        end
+    end
+  end
+end

--- a/app/controllers/themes_controller.rb
+++ b/app/controllers/themes_controller.rb
@@ -4,7 +4,7 @@ class ThemesController < ApplicationController
   def index
     respond_to do |format|
       format.html {
-        @pagy, @themes = pagy(query_themes)
+        @pagy, @themes = pagy(query_themes.includes(:theme_usages, :assets))
       }
 
       format.json {

--- a/app/models/app_user.rb
+++ b/app/models/app_user.rb
@@ -72,6 +72,9 @@ class AppUser < ApplicationRecord
   has_one  :app_user_reason
   has_one  :reason, through: :app_user_reason
 
+  has_many :theme_usages
+  has_many :themes, through: :theme_usages
+
   # Callback
   before_create :set_last_accessed_at
   before_validation :set_province_id

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -25,6 +25,8 @@ class Theme < ApplicationRecord
 
   # Association
   has_many :assets, dependent: :destroy
+  has_many :theme_usages
+  has_many :app_users, through: :theme_usages
 
   # Validation
   validates :name, presence: true, uniqueness: true, length: { maximum: 15 }

--- a/app/models/theme_usage.rb
+++ b/app/models/theme_usage.rb
@@ -1,0 +1,18 @@
+# == Schema Information
+#
+# Table name: theme_usages
+#
+#  id          :uuid             not null, primary key
+#  app_user_id :uuid             not null
+#  theme_id    :uuid             not null
+#  applied_at  :datetime         not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+class ThemeUsage < ApplicationRecord
+  belongs_to :app_user
+  belongs_to :theme
+
+  # Validation
+  validates :applied_at, presence: true
+end

--- a/app/views/themes/index.html.haml
+++ b/app/views/themes/index.html.haml
@@ -20,6 +20,8 @@
             %th= t('theme.category')
             %th= t('theme.num_of_bg_image')
             %th= t('shared.updated_at')
+            %th= t('theme.num_of_uniq_users')
+            %th= t('theme.num_of_uses')
             %th
         %tbody
           - @themes.each_with_index do |theme, index|
@@ -32,6 +34,8 @@
                 = t('theme.built_in') if theme.default?
               %td= theme.assets.length
               %td= timeago(theme.updated_at, type: 'datetime').html_safe
+              %td= theme.theme_usages.pluck(:app_user_id).uniq.length
+              %td= theme.theme_usages.length
               %td
                 .d-flex.justify-content-end
                   - if policy(theme).publish?

--- a/config/locales/theme/en.yml
+++ b/config/locales/theme/en.yml
@@ -51,3 +51,5 @@ en:
     bg_image_tip:
       how_to_use: This image serves as the <strong>top-layer background</strong>, overlaying the <strong>solid background color</strong> beneath it when the theme is applied. It is designed to <strong>adapt seamlessly</strong> across various platforms, including <strong>Android and iOS</strong>, and supports <strong>multiple resolutions</strong> to ensure <strong>optimal display quality</strong>. This includes sizes such as <code>1x</code>, <code>2x</code>, and <code>3x</code>, as well as densities like <code>MDPI</code>, <code>HDPI</code>, <code>XHDPI</code>, and <code>XXHDPI</code> for a wide range of devices and screen specifications.
       user_update_bg_image: Users can <strong>edit the built-in theme’s background image</strong>, though the <strong>background color cannot be modified</strong>. Editing of the background image is permitted <strong>only when the theme is in draft mode</strong>.
+    num_of_uniq_users: "# Unique Users"
+    num_of_uses: "# Uses"

--- a/config/locales/theme/km.yml
+++ b/config/locales/theme/km.yml
@@ -51,3 +51,5 @@ km:
     bg_image_tip:
       how_to_use: រូបភាពនេះប្រើជា <strong>ផ្ទៃខាងក្រោយនិងគ្របពីលើ</strong> Background Color ខាងលើ។ វាត្រូវបានរចនាឡើងដើម្បី <strong>សម្របខ្លួនយ៉ាងរលូន</strong> នៅលើវេទិកាផ្សេងៗ រួមទាំង <strong>Android និង iOS</strong> និងគាំទ្រ <strong>ដំណោះស្រាយច្រើន</strong> ដើម្បីធានាបាននូវ <strong>គុណភាពបង្ហាញល្អបំផុត</strong>។ នេះរួមបញ្ចូលទំហំដូចជា <code>1x</code>, <code>2x</code> និង <code>3x</code>សម្រាប់​ iOS ក៏ដូចជា <code>MDPI</code>, <code>HDPI</code>, <code>XHDPI</code>, និង <code>XXHDPI</code> សម្រាប់ Android ដើម្បី​គាំទ្រទៅឧបករណ៍ដ៏ច្រើន និងលក្ខណៈពិសេសអេក្រង់។
       user_update_bg_image: សម្រាប់ Theme ដែលមានស្រាប់ក្នុងប្រព័ន្ធ<code>(Built-in theme)</code> អ្នកប្រើប្រាស់អាច<strong>កែសម្រួលរូបភាពទាំងនេះ</strong> ប៉ុន្តែមិនអាចកែប្រែ<strong>ពណ៌ផ្ទៃខាងក្រោយខាងលើបានទេ</strong>។ ម្យ៉ាងទៀ​ ការ​កែ​សម្រួល​រូបភាព​ផ្ទៃ​ខាង​ក្រោយ​ត្រូវ​បាន​អនុញ្ញាត​តែ​នៅ​ពេល​ដែល Theme ស្ថិត​នៅ​ក្នុង​ទម្រង់​ព្រាង​<code>(draft)</code> ប៉ុណ្ណោះ</strong>។
+    num_of_uniq_users: "ចំនួនអ្នកប្រើប្រាស់"
+    num_of_uses: "ចំនួនប្រើប្រាស់"

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
       resources :survey_answers, only: [:update]
       resources :reasons, only: [:index]
       resources :themes, only: [:index, :show]
+      resources :theme_usages, only: [:create]
 
       get "*path" => "api#routing_error"
     end

--- a/db/migrate/20250421030659_create_theme_usages.rb
+++ b/db/migrate/20250421030659_create_theme_usages.rb
@@ -1,0 +1,11 @@
+class CreateThemeUsages < ActiveRecord::Migration[7.0]
+  def change
+    create_table :theme_usages, id: :uuid do |t|
+      t.uuid :app_user_id, null: false
+      t.uuid :theme_id, null: false
+      t.datetime :applied_at, null: false, default: -> { "CURRENT_TIMESTAMP" }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_04_20_074207) do
+ActiveRecord::Schema[7.0].define(version: 2025_04_21_030659) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -467,6 +467,14 @@ ActiveRecord::Schema[7.0].define(version: 2025_04_20_074207) do
     t.string "telegram_bot_user_id"
     t.boolean "enabled", default: false
     t.boolean "active", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "theme_usages", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "app_user_id", null: false
+    t.uuid "theme_id", null: false
+    t.datetime "applied_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/spec/factories/theme_usages.rb
+++ b/spec/factories/theme_usages.rb
@@ -1,0 +1,18 @@
+# == Schema Information
+#
+# Table name: theme_usages
+#
+#  id          :uuid             not null, primary key
+#  app_user_id :uuid             not null
+#  theme_id    :uuid             not null
+#  applied_at  :datetime         not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+FactoryBot.define do
+  factory :theme_usage do
+    app_user
+    theme
+    applied_at { Time.current }
+  end
+end

--- a/spec/models/app_user_spec.rb
+++ b/spec/models/app_user_spec.rb
@@ -27,6 +27,9 @@ RSpec.describe AppUser, type: :model do
   it { is_expected.to have_many(:app_user_characteristics) }
   it { is_expected.to have_many(:characteristics).through(:app_user_characteristics) }
 
+  it { is_expected.to have_many(:theme_usages) }
+  it { is_expected.to have_many(:themes).through(:theme_usages) }
+
   describe "#anonymous?" do
     it "returns true" do
       subject.age = -1

--- a/spec/models/theme_spec.rb
+++ b/spec/models/theme_spec.rb
@@ -41,6 +41,8 @@ RSpec.describe Theme, type: :model do
   # Association
   describe "associations" do
     it { is_expected.to have_many(:assets).dependent(:destroy) }
+    it { is_expected.to have_many(:theme_usages) }
+    it { is_expected.to have_many(:app_users).through(:theme_usages) }
   end
 
   # Validation

--- a/spec/models/theme_usage_spec.rb
+++ b/spec/models/theme_usage_spec.rb
@@ -1,0 +1,42 @@
+# == Schema Information
+#
+# Table name: theme_usages
+#
+#  id          :uuid             not null, primary key
+#  app_user_id :uuid             not null
+#  theme_id    :uuid             not null
+#  applied_at  :datetime         not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+require 'rails_helper'
+
+RSpec.describe ThemeUsage, type: :model do
+  # Association tests
+  describe "associations" do
+    it { should belong_to(:app_user) }
+    it { should belong_to(:theme) }
+  end
+
+  # Validation tests
+  describe "validations" do
+    it { should validate_presence_of(:applied_at) }
+  end
+
+  # Factory setup and basic tests
+  describe "with valid attributes" do
+    let(:theme_usage) { create(:theme_usage) }
+
+    it "is valid with valid attributes" do
+      expect(theme_usage).to be_valid
+    end
+  end
+
+  describe "with invalid attributes" do
+    it "is invalid without applied_at" do
+      theme_usage = build(:theme_usage, applied_at: nil)
+      expect(theme_usage).not_to be_valid
+      expect(theme_usage.errors[:applied_at]).to include("can't be blank")
+    end
+  end
+end

--- a/spec/requests/api/v1/theme_usages_request_spec.rb
+++ b/spec/requests/api/v1/theme_usages_request_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V1::ThemeUsagesController, type: :request do
+  let(:api_key) { create(:api_key) }
+  let(:headers) { { "ACCEPT" => "application/json", "Authorization" => "Apikey #{api_key.api_key}" } }
+  let(:json_response) { JSON.parse(response.body) }
+
+  describe "POST /api/v1/theme_usages" do
+    let!(:app_user) { create(:app_user) }
+    let!(:theme) { create(:theme) }
+
+    let(:valid_params) do
+      {
+        theme_usage: {
+          app_user_id: app_user.id,
+          theme_id: theme.id,
+          applied_at: DateTime.yesterday
+        }
+      }
+    end
+
+    context "with valid parameters" do
+      it "creates a new app user theme" do
+        expect {
+          post "/api/v1/theme_usages", params: valid_params, headers:
+        }.to change { ThemeUsage.count }.by(1)
+
+        expect(response).to have_http_status(:created)
+        expect(json_response).to include(
+          "app_user_id" => app_user.id,
+          "theme_id" => theme.id
+        )
+      end
+    end
+
+    context "with invalid parameters" do
+      let(:invalid_params) do
+        {
+          theme_usage: {
+            app_user_id: app_user.id,
+            theme_id: nil, # Invalid theme_id
+            applied_at: DateTime.yesterday
+          }
+        }
+      end
+
+      it "does not create an app user theme and returns an error" do
+        expect {
+          post "/api/v1/theme_usages", params: invalid_params, headers:
+        }.not_to change { ThemeUsage.count }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json_response["errors"]["theme"]).to include("must exist")
+      end
+    end
+
+    context "with invalid app_user_id" do
+      let(:invalid_user_params) do
+        {
+          theme_usage: {
+            app_user_id: -1, # Non-existent user
+            theme_id: theme.id,
+            applied_at: DateTime.yesterday
+          }
+        }
+      end
+
+      it "does not create an app user theme and returns an error" do
+        expect {
+          post "/api/v1/theme_usages", params: invalid_user_params, headers:
+        }.not_to change { ThemeUsage.count }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json_response["errors"]["app_user"]).to include("must exist")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Implement User Themes API for Tracking Theme Usage

### Key Changes

1. **Database and Models**:
   - Created an `ThemeUsages` table to log theme usage with `app_user_id`, `theme_id`, and `applied_at` (timestamp).

2. **API Endpoints** (under `Api::V1` namespace):
   - **POST /api/v1/theme_usages**:
     - Allows the mobile app to report a user’s theme change by sending `theme_id`, `app_user_id`, and `applied_at`.
     - Validates `theme_id` and `app_user_id`, returning the created record (`theme_id`, `theme_name`, etc.) on success or an error (422) on failure.

3. **Update admin page: theme list**
- Display `# Uniq users`
- Display `# Uses`
- Fix N+1 query for theme list

### Why This Change?
- Fulfills the client’s request to track user theme usage without losing historical data (e.g., preserving "10 users used Theme A in October" even if they switch to Theme B in November).
- Provides a robust API for the mobile app to report themes, enabling analytics on theme popularity.

### How to Test

1. **API**:
   - Use Postman or cURL to test endpoints:
     - `POST /api/v1/theme_usages` with valid/invalid params (e.g., `{ "theme_usage": { "app_user_id": 1, "theme_id": 1, "applied_at": "2025-10-01T00:00:00Z" } }`).

**Screenshot**
<img width="1498" alt="Screenshot 2025-04-21 at 8 55 48 AM" src="https://github.com/user-attachments/assets/e931eaec-a708-4e9b-8316-c061a9650573" />
