### PR TITLE
Theme name: apply max length to 32 characters

### DIFF
--- a/app/helpers/themes_helper.rb
+++ b/app/helpers/themes_helper.rb
@@ -51,6 +51,17 @@ module ThemesHelper
     ]
   end
 
+  def theme_name_tip
+    content = %Q{
+      <h5 class="text-dark">#{t('theme.name_with_max_length')}</h5>
+      <ul class="ps-3 mt-2">
+        <li>#{t('theme.name_tip.separate_line_by_space')}</li>
+      </ul>
+    }
+
+    render_popover(nil, content)
+  end
+
   def create_theme_tip
     title = t("theme.tip.title")
     content = %Q{

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -29,7 +29,7 @@ class Theme < ApplicationRecord
   has_many :app_users, through: :theme_usages
 
   # Validation
-  validates :name, presence: true, uniqueness: true, length: { maximum: 15 }
+  validates :name, presence: true, uniqueness: true, length: { maximum: 32 }
   validates :primary_color, presence: true
   validates :secondary_color, presence: true
 

--- a/app/views/themes/_form.html.haml
+++ b/app/views/themes/_form.html.haml
@@ -3,9 +3,11 @@
     = simple_form_for @theme, html: {} do |f|
       .mb-3
         .d-flex
-          = f.label :name, "#{t('theme.name_with_max_length')} <abbr title='required'>*</abbr>".html_safe, class: 'flex-grow-1'
-          = create_theme_tip
-        = f.input :name, label: false, disabled: policy(@theme).disable_edit?, maxlength: 15
+          = f.label :name, "#{t('theme.name_with_max_length')} <abbr title='required'>*</abbr>".html_safe
+          = theme_name_tip
+          .flex-grow-1.text-end
+            = create_theme_tip
+        = f.input :name, label: false, disabled: policy(@theme).disable_edit?, maxlength: 32
       .mb-3
         .d-flex
           = f.label :primary_color, "#{t('theme.primary_color')} <abbr title='required'>*</abbr>".html_safe

--- a/config/locales/theme/en.yml
+++ b/config/locales/theme/en.yml
@@ -3,7 +3,7 @@ en:
     themes: Themes
     theme: Theme
     name: Name
-    name_with_max_length: Name (maximum 15 characters)
+    name_with_max_length: Name (max 32 characters)
     primary_color: Primary color
     secondary_color: Secondary color
     active: Active
@@ -53,3 +53,5 @@ en:
       user_update_bg_image: Users can <strong>edit the built-in theme’s background image</strong>, though the <strong>background color cannot be modified</strong>. Editing of the background image is permitted <strong>only when the theme is in draft mode</strong>.
     num_of_uniq_users: "# Unique Users"
     num_of_uses: "# Uses"
+    name_tip:
+      separate_line_by_space: "Separate line by space"

--- a/config/locales/theme/km.yml
+++ b/config/locales/theme/km.yml
@@ -3,7 +3,7 @@ km:
     themes: Themes
     theme: Theme
     name: ឈ្មោះ
-    name_with_max_length: ឈ្មោះ (អតិបរិមា 15តួ)
+    name_with_max_length: ឈ្មោះ (អតិបរិមា 32តួ)
     primary_color: ពណ៌ចម្បង (Primary color)
     secondary_color: ពណ៌បន្ទាប់បន្សំ (Secondary color)
     active: ចេញផ្សាយ
@@ -53,3 +53,5 @@ km:
       user_update_bg_image: សម្រាប់ Theme ដែលមានស្រាប់ក្នុងប្រព័ន្ធ<code>(Built-in theme)</code> អ្នកប្រើប្រាស់អាច<strong>កែសម្រួលរូបភាពទាំងនេះ</strong> ប៉ុន្តែមិនអាចកែប្រែ<strong>ពណ៌ផ្ទៃខាងក្រោយខាងលើបានទេ</strong>។ ម្យ៉ាងទៀ​ ការ​កែ​សម្រួល​រូបភាព​ផ្ទៃ​ខាង​ក្រោយ​ត្រូវ​បាន​អនុញ្ញាត​តែ​នៅ​ពេល​ដែល Theme ស្ថិត​នៅ​ក្នុង​ទម្រង់​ព្រាង​<code>(draft)</code> ប៉ុណ្ណោះ</strong>។
     num_of_uniq_users: "ចំនួនអ្នកប្រើប្រាស់"
     num_of_uses: "ចំនួនប្រើប្រាស់"
+    name_tip:
+      separate_line_by_space: "ចុះបន្ទាត់ដោយសញ្ញាដកឃ្លា"

--- a/lib/samples/assets/csv/themes.csv
+++ b/lib/samples/assets/csv/themes.csv
@@ -1,4 +1,4 @@
 name,default,status,primary_color,secondary_color
-Youth Health,true,published,#1b91f7,#fa60ad
-Turqu Vibrant,true,published,#00ced1,#ff69b4
-Pink Vibrant,true,published,#ff69b4,#29abe2
+ក្លាសិក (លំនាំដើម),true,published,#1b91f7,#fa60ad
+សម័យ (ខៀវខ្ចី),true,published,#00ced1,#ff69b4
+យុវវ័យ (ស៊ីជំពូ),true,published,#ff69b4,#29abe2

--- a/spec/models/theme_spec.rb
+++ b/spec/models/theme_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Theme, type: :model do
   describe "validations" do
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_uniqueness_of(:name) }
-    it { is_expected.to validate_length_of(:name).is_at_most(15) }
+    it { is_expected.to validate_length_of(:name).is_at_most(32) }
     it { is_expected.to validate_presence_of(:primary_color) }
     it { is_expected.to validate_presence_of(:secondary_color) }
   end


### PR DESCRIPTION
## Why?
- Increase theme name character limit from 15 to 32 characters for greater flexibility and user customization.

## How?
- Modify the theme model to support a 32-character name field.
- Update the user interface (view) to reflect the new character limit.
- Add a tooltip or hint to inform users about the updated name length. `Separate line by space` in EN and `ចុះបន្ទាត់ដោយសញ្ញាដកឃ្លា` in KM
- Revise the specification document to document the new limit.

## Screenshot
<img width="920" alt="Screenshot 2025-04-21 at 9 43 59 AM" src="https://github.com/user-attachments/assets/1365c99a-2071-451d-87f5-68e736de4965" />
