### PR TITLE
Mobile notification: add app version to form and filter when push notification

### DIFF
--- a/app/assets/stylesheets/selectpicker.scss
+++ b/app/assets/stylesheets/selectpicker.scss
@@ -22,3 +22,7 @@
 .dropdown-item.active, .dropdown-item:active {
   background-color: rgba(0,0,0,0.05);
 }
+
+.dropdown-menu.show {
+  z-index: 1040;
+}

--- a/app/controllers/mobile_notifications_controller.rb
+++ b/app/controllers/mobile_notifications_controller.rb
@@ -5,6 +5,7 @@ class MobileNotificationsController < ApplicationController
 
   def new
     @mobile_notification = authorize MobileNotification.new
+    load_app_versions
   end
 
   def create
@@ -13,6 +14,7 @@ class MobileNotificationsController < ApplicationController
     if @mobile_notification.save
       redirect_to mobile_notifications_url
     else
+      load_app_versions
       render :new
     end
   end
@@ -27,11 +29,15 @@ class MobileNotificationsController < ApplicationController
   private
     def notification_params
       params.require(:mobile_notification).permit(
-        :id, :title, :body, :platform, :schedule_date, :topic_id
+        :id, :title, :body, :platform, :schedule_date, :topic_id, app_versions: []
       ).merge(creator_id: current_user.id)
     end
 
     def filter_params
       params.permit(:title, :start_date, :end_date, :topic_id)
+    end
+
+    def load_app_versions
+      @app_versions = MobileToken.pluck(:app_version).uniq.sort_by { |v| Gem::Version.new(v) }.reverse
     end
 end

--- a/app/javascript/controllers/mobile_notifications_controller.js
+++ b/app/javascript/controllers/mobile_notifications_controller.js
@@ -15,6 +15,20 @@ export default class extends Controller {
     this.picker = new tempusDominus.TempusDominus(document.getElementById('schedule_date'), options);
   }
 
+  toggleAppVersion(event) {
+    const selectElement = event.target;
+    const appVersionContainer = document.getElementById('appVersion');
+    const appVersionTitle = appVersionContainer.querySelector('label span');
+
+    if (selectElement.value) {
+      appVersionTitle.textContent = selectElement.options[selectElement.selectedIndex].text;
+      appVersionContainer.classList.remove('d-none');
+    } else {
+      appVersionContainer.classList.add('d-none');
+      $('#appVersion select').selectpicker('val', []);
+    }
+  }
+
   updateTitle(e) {
     this.titleTarget.innerHTML = e.target.value;
     this.titleCountTarget.innerHTML = e.target.value.length;

--- a/app/javascript/controllers/sidebar_controller.js
+++ b/app/javascript/controllers/sidebar_controller.js
@@ -8,7 +8,7 @@ export default class extends Controller {
   _initShowCollapse() {
     let element = $(".sb-sidenav-menu-nested .nav-link.active")
 
-    if (!!element) {
+    if (!!element && element.offset()) {
       element.parents(".collapse").addClass('show')
 
       $('.sb-sidenav-menu').animate({

--- a/app/models/mobile_token.rb
+++ b/app/models/mobile_token.rb
@@ -33,7 +33,7 @@ class MobileToken < ApplicationRecord
   }
 
   # Constant
-  PLATFORMS = [["Android", "android"], ["iOs", "ios"]]
+  PLATFORMS = [["Android", "android"], ["iOS", "ios"]]
 
   # Class methods
   def self.filter(params = {})

--- a/app/sidekiq/mobile_notification_job.rb
+++ b/app/sidekiq/mobile_notification_job.rb
@@ -11,7 +11,7 @@ class MobileNotificationJob
 
   private
     def mobile_tokens
-      MobileToken.filter(platform: @notification.platform).actives
+      MobileToken.filter(platform: @notification.platform, app_versions: @notification.app_versions).actives
     end
 
     def push_notifications

--- a/app/views/mobile_notifications/_form.html.haml
+++ b/app/views/mobile_notifications/_form.html.haml
@@ -1,4 +1,4 @@
-.d-flex.mobile-notifications-form.flex-md-row.flex-column-reverse{'data-controller': 'mobile-notifiations'}
+.d-flex.mobile-notifications-form.flex-md-row.flex-column-reverse{'data-controller': 'mobile-notifications'}
   .flex-1.me-md-4
     = simple_form_for @mobile_notification do |f|
       / Title
@@ -8,10 +8,10 @@
           = "(#{t('mobile_notification.max_title')})"
           %abbr.text-danger{title: 'required'} *
 
-        = f.input :title, label: false, input_html: { maxlength: 100, 'data-action': 'mobile-notifiations#updateTitle' }
+        = f.input :title, label: false, input_html: { maxlength: 100, 'data-action': 'mobile-notifications#updateTitle' }
 
         .text-end.small
-          %span.title-count{'data-mobile-notifiations-target': 'titleCount'} 0
+          %span.title-count{'data-mobile-notifications-target': 'titleCount'} 0
           %span /
           %span 100
 
@@ -22,18 +22,26 @@
           = "(#{t('mobile_notification.max_body')})"
           %abbr.text-danger{title: 'required'} *
 
-        = f.input :body, label: false, input_html: { maxlength: 255, 'data-action': 'mobile-notifiations#updateBody' }
+        = f.input :body, label: false, input_html: { maxlength: 255, 'data-action': 'mobile-notifications#updateBody' }
 
         .text-end.small
-          %span.body-count{'data-mobile-notifiations-target': 'bodyCount'} 0
+          %span.body-count{'data-mobile-notifications-target': 'bodyCount'} 0
           %span /
           %span 255
 
       / Platform
-      .mb-3
-        = f.input :platform, collection: MobileToken::PLATFORMS, label: t('shared.platform'), include_blank: true, input_html: {class: 'selectpicker', "data-none-selected-text" => t('visit.any_platform')}
+      .mb-4
+        = f.input :platform, collection: MobileToken::PLATFORMS, label: t('shared.platform'), include_blank: true, input_html: {class: 'selectpicker', "data-none-selected-text" => t('visit.any_platform'), 'data-mobile-notifications-target': 'platform', 'data-action': 'mobile-notifications#toggleAppVersion'}
 
-      .mb-3
+      .mb-4.filter-input.tooltips.w-100#appVersion{ 'data-bs-toggle' => 'tooltip', class: ('d-none' unless f.object.platform.present?) }
+        %label
+          = t('mobile_notification.app_version')
+          %span
+            = t("mobile_notification.#{f.object.platform}") if f.object.platform.present?
+
+        = select_tag 'mobile_notification[app_versions][]', options_for_select(@app_versions, f.object.app_versions), multiple: true, "data-live-search" => "true", "data-count-selected-text" => "{0} #{t('mobile_notification.app_version_selected')}", "data-selected-text-format" => "count > 5", "data-none-selected-text" => t('mobile_notification.any_version'), class: 'selectpicker form-control'
+
+      .mb-4
         %label
           = t("mobile_notification.questionnaire_to_be_used")
           %small= link_to "(#{t('mobile_notification.view_all_survey_form')})", survey_forms_path, class: 'text-primary', target: '_blank'
@@ -41,7 +49,7 @@
         = f.input :topic_id, collection: Topics::SurveyForm.all.map{|f| ["#{f.name} (#{f.status})", f.id]}, label: false, include_blank: true, input_html: {class: 'selectpicker', "data-none-selected-text" => t('shared.please_select')}
 
       / Schedule date
-      .mb-3
+      .mb-4
         %label= t('mobile_notification.schedule_date')
 
         #schedule_date.input-group.date{"data-target-input" => "nearest"}
@@ -54,7 +62,7 @@
       / Action
       .actions.text-right
         = link_to t('shared.cancel'), mobile_notifications_url, class: 'btn btn-secondary me-1'
-        = f.submit t('mobile_notification.push_notification'), class: 'btn btn-primary', 'data-action': 'mobile-notifiations#submit'
+        = f.submit t('mobile_notification.push_notification'), class: 'btn btn-primary', 'data-action': 'mobile-notifications#submit'
 
   / Preview
   %div
@@ -66,5 +74,5 @@
           .flex-1.small= ENV["APP_NAME"]
 
         .text-wrapper.mt-2
-          .title.text-truncate{'data-mobile-notifiations-target': 'title'}
-          .text-body.text-truncate{'data-mobile-notifiations-target': 'body'}
+          .title.text-truncate{'data-mobile-notifications-target': 'title'}
+          .text-body.text-truncate{'data-mobile-notifications-target': 'body'}

--- a/app/views/mobile_notifications/index.html.haml
+++ b/app/views/mobile_notifications/index.html.haml
@@ -18,6 +18,7 @@
             %th= t('mobile_notification.notification_text')
             %th= t('form.questionnaire')
             %th= t('mobile_notification.platform')
+            %th= t('mobile_notification.app_version')
             %th= t('shared.created_at')
             %th= t('mobile_notification.schedule_date')
             %th= t('shared.description')
@@ -33,6 +34,7 @@
               %td
                 = link_to notification.survey_form_name, survey_form_path(notification.survey_form), class: 'text-primary', remote: true if notification.survey_form.present?
               %td= platform_icon(notification.platform).html_safe
+              %td= notification.app_versions.present? ? notification.app_versions.join(', ') : t('mobile_notification.all_version')
               %td= timeago(notification.created_at).html_safe
               %td= notification.schedule_date.future? ? l(notification.schedule_date, format: :long) : timeago(notification.schedule_date, 'datetime').html_safe
 

--- a/config/locales/mobile_notification/en.yml
+++ b/config/locales/mobile_notification/en.yml
@@ -33,3 +33,6 @@ en:
     view_all_survey_form: View all survey forms
     any_survey_form: Any survey form
     notify_to: Notify to
+    app_version_selected: app version selected
+    ios: iOS
+    android: Android

--- a/config/locales/mobile_notification/km.yml
+++ b/config/locales/mobile_notification/km.yml
@@ -33,3 +33,6 @@ km:
     view_all_survey_form: ចូលមើលកម្រងសំនួរ
     any_survey_form: គ្រប់កម្រងសំណួរ
     notify_to: ការជូនដំណឹងទៅកាន់
+    app_version_selected: លេខកំណែកម្មវិធីដែលបានជ្រើសរើស
+    ios: iOS
+    android: Android

--- a/spec/sidekiq/mobile_notification_job_spec.rb
+++ b/spec/sidekiq/mobile_notification_job_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe MobileNotificationJob, type: :job do
   let(:notification) { create(:mobile_notification) }
-  let(:mobile_tokens) { create_list(:mobile_token, 3, platform: notification.platform, active: true) }
+  let(:mobile_tokens) { create_list(:mobile_token, 3, platform: notification.platform, app_version: '2.0.0', active: true) }
   let(:push_notification_service) { PushNotificationService.new(notification) }
   let(:result) { { success_count: 2, failure_count: 1, detail: "Some detail" } }
 
@@ -45,12 +45,33 @@ RSpec.describe MobileNotificationJob, type: :job do
   end
 
   describe "#mobile_tokens" do
-    it "returns active mobile tokens for the notification platform" do
-      job = described_class.new
+    let(:job) { described_class.new }
+
+    before do
       job.instance_variable_set(:@notification, notification)
+    end
+
+    it "returns active mobile tokens for the notification platform" do
       mobile_tokens.first.update(active: false)
 
       expect(job.send(:mobile_tokens).count).to eq(2)
+    end
+
+    context 'when there are matching app_version and active 2 tokens' do
+      it "returns mobile tokens with the correct platform and app versions" do
+        mobile_tokens.first.update(active: false)
+        notification.update(app_versions: ['2.0.0'])
+
+        expect(job.send(:mobile_tokens).count).to eq(2)
+      end
+    end
+
+    context 'when there are no matching app_version' do
+      it "returns mobile tokens with the correct platform and app versions" do
+        notification.update(app_versions: ['1.0.0'])
+
+        expect(job.send(:mobile_tokens).count).to eq(0)
+      end
     end
   end
 


### PR DESCRIPTION
## What does this PR do?

1. **Add App Version Selection to Notification Form**
   - Adds a multi-select dropdown for app versions in the notification form, displayed when a specific platform is selected.
   - Hides and clears the app version selection when switching to the "All" platform option.
   - Uses a select picker for the app version controller.
   - Displays "N app versions selected" when more than 5 versions are chosen to shorten the display.

2. **Filter Mobile Tokens for Push Notifications**
   - Applies app version filtering to mobile tokens during push notification delivery.

## Screenshot
<img width="1491" alt="1" src="https://github.com/user-attachments/assets/ec05fb75-d8e8-4923-98eb-149b7fbec4f6" />
<img width="1469" alt="2" src="https://github.com/user-attachments/assets/d8bd3a61-b9b0-4d61-af2b-423e109ed52c" />
<img width="1289" alt="3" src="https://github.com/user-attachments/assets/69414986-cb95-479b-86ec-6d3263386d0a" />
