### PR TITLE
Survey form: display # of participation column

### DIFF
--- a/app/controllers/survey_forms_controller.rb
+++ b/app/controllers/survey_forms_controller.rb
@@ -4,7 +4,7 @@ class SurveyFormsController < ApplicationController
   before_action :authorize_form, only: [:show, :edit, :update, :destroy, :make_a_copy]
 
   def index
-    @pagy, @forms = pagy(policy_scope(Topics::SurveyForm.filter(filter_params).includes(:questions, :mobile_notifications)))
+    @pagy, @forms = pagy(policy_scope(Topics::SurveyForm.filter(filter_params).includes(:questions, :mobile_notifications, :surveys)))
   end
 
   def show

--- a/app/models/topics/survey_form.rb
+++ b/app/models/topics/survey_form.rb
@@ -19,6 +19,7 @@ module Topics
     # Association
     has_many :mobile_notifications, foreign_key: :topic_id
     has_many :questions, through: :sections
+    has_many :surveys, class_name: 'Survey', foreign_key: 'topic_id'
 
     # Validation
     validates_associated :sections

--- a/app/views/survey_forms/index.html.haml
+++ b/app/views/survey_forms/index.html.haml
@@ -24,6 +24,7 @@
           %th= t('form.name_en')
           %th= t('form.number_of_question')
           %th= t('form.number_of_notification')
+          %th= t('form.number_of_participation')
           %th= t('shared.tags')
           %th= t('shared.description')
           %th= t('shared.status')
@@ -37,6 +38,8 @@
             %td= form.questions.length
             %td
               = link_to form.mobile_notifications.length, mobile_notifications_path(topic_id: form.id), class: 'text-primary' if form.mobile_notifications.length.positive?
+            %td
+              = form.surveys.count if form.surveys.any?
             %td= form.tag_list
             %td= form.description
             %td= form_status_html(form).html_safe

--- a/config/locales/topic/en.yml
+++ b/config/locales/topic/en.yml
@@ -51,3 +51,4 @@ en:
     add_option: + Add option
     add_question: + Add question
     option_icon_hint: The icon file(*.png, and 80px x 80px)
+    number_of_participation: "# of participation"

--- a/config/locales/topic/km.yml
+++ b/config/locales/topic/km.yml
@@ -51,3 +51,4 @@ km:
     add_option: + បន្ថែមជម្រើស
     add_question: + បន្ថែមសំណួរ
     option_icon_hint: រូបតំណាង(*.png, and 80px x 80px)
+    number_of_participation: "# ចំនួននៃការចូលរួម"

--- a/lib/samples/survey.rb
+++ b/lib/samples/survey.rb
@@ -3,7 +3,7 @@ module Samples
     def load
       ::Survey.create(
         app_user:,
-        topic:,
+        survey_form: survey_form,
         quizzed_at: rand(1..5).days.ago,
         survey_answers_attributes:
       )
@@ -14,12 +14,12 @@ module Samples
         @app_user ||= ::AppUser.all.sample
       end
 
-      def topic
+      def survey_form
         @topic ||= ::Topics::SurveyForm.all.sample
       end
 
       def survey_answers_attributes
-        topic.questions.map do |question|
+        survey_form.questions.map do |question|
           option = question.options.sample
 
           {

--- a/spec/models/survey_form_spec.rb
+++ b/spec/models/survey_form_spec.rb
@@ -1,6 +1,22 @@
 require "rails_helper"
 
 RSpec.describe Topics::SurveyForm, type: :model do
+  # Test inheritance
+  it { is_expected.to be_a(::Topic) }
+
+  # Test Associations
+  describe 'associations' do
+    it { is_expected.to have_many(:mobile_notifications).with_foreign_key(:topic_id) }
+    it { is_expected.to have_many(:questions).through(:sections) }
+    it { is_expected.to have_many(:surveys).class_name('Survey').with_foreign_key(:topic_id) }
+  end
+
+  describe '.policy_class' do
+    it 'returns SurveyFormPolicy' do
+      expect(described_class.policy_class).to eq(SurveyFormPolicy)
+    end
+  end
+
   describe "#deep_copy" do
     let(:survey) do
       create(:survey_form, name_en: "Test Survey", name_km: "សាកល្បង", code: "TS", tag_list: ["survey", "test"])


### PR DESCRIPTION
## What does this PR do?

- Adds display of `# of participations` column in the survey form list.
- Updates logic to reflect the number of surveys completed.
- Implements model association for accurate data retrieval.
- Chore: Updates run sample to align with changes.

## Screenshot
<img width="1502" alt="Screenshot 2025-05-06 at 11 27 09 AM" src="https://github.com/user-attachments/assets/b2ae98f7-278e-4cd5-83b0-959b5f089725" />
