### PR TITLE
Survey: display survey list and allow to download as csv and excel file

### DIFF
--- a/app/controllers/survey_forms/surveys_controller.rb
+++ b/app/controllers/survey_forms/surveys_controller.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module SurveyForms
+  class SurveysController < ApplicationController
+    before_action :load_survey_form, only: [:index]
+    helper_method :filter_params
+
+    MAX_DOWNLOAD_RECORD = Settings.max_download_record
+
+    def index
+      @surveys = query_surveys
+
+      respond_to do |format|
+        format.html { paginate_surveys }
+        format.xlsx {
+          @surveys = @surveys.includes(app_user: :characteristics)
+          export_xlsx
+        }
+        format.csv {
+          @surveys = @surveys.includes(app_user: :characteristics)
+          export_csv
+        }
+      end
+    end
+
+    private
+      def load_survey_form
+        @survey_form = Topics::SurveyForm.find(params[:survey_form_id])
+      end
+
+      def filter_params
+        params.permit(:start_date, :end_date, :survey_form_id)
+      end
+
+      def query_surveys
+        authorize policy_scope(Survey.filter(filter_params).includes(:survey_answers))
+      end
+
+      def paginate_surveys
+        @pagy, @surveys = pagy(@surveys)
+      end
+
+      def export_xlsx
+        return handle_export_limit_exceeded if export_limit_exceeded?
+
+        render xlsx: "index", filename: export_filename("xlsx")
+      end
+
+      def export_csv
+        return handle_export_limit_exceeded if export_limit_exceeded?
+
+        send_data view_context.build_csv_data(@survey_form, @surveys),
+                  filename: export_filename("csv"),
+                  type: "text/csv"
+      end
+
+      def export_limit_exceeded?
+        @surveys.length > MAX_DOWNLOAD_RECORD
+      end
+
+      def handle_export_limit_exceeded
+        flash[:alert] = t("shared.file_size_is_too_big", max_record: MAX_DOWNLOAD_RECORD)
+        redirect_to survey_form_surveys_url(@survey_form)
+      end
+
+      def export_filename(extension)
+        "#{@survey_form.name}_#{Time.current.strftime('%Y%m%d_%H%M%S')}.#{extension}"
+      end
+  end
+end

--- a/app/helpers/surveys_helper.rb
+++ b/app/helpers/surveys_helper.rb
@@ -1,0 +1,34 @@
+module SurveysHelper
+  def build_csv_data(survey_form, surveys)
+    CSV.generate(headers: true) do |csv|
+      csv << build_survey_header(survey_form)
+
+      surveys.each do |survey|
+        csv << build_survey_row(survey, survey_form)
+      end
+    end
+  end
+
+  def build_survey_header(survey_form)
+    user_headers = %w[_id _gender _age _province _occupation _education_level _characteristic]
+    question_headers = survey_form.questions.map(&:name)
+    time_headers = %w[_submission_time _quizzed_time]
+    user_headers + question_headers + time_headers
+  end
+
+  def build_survey_row(survey, survey_form)
+    user = survey.app_user
+    row = [
+      user.id[0..7],
+      user.gender || "annonymous",
+      user.age,
+      (user.province["name_#{I18n.locale}"] unless user.anonymous?),
+      t("app_user.#{user.occupation}"),
+      t("app_user.#{user.education_level}"),
+      user.characteristics.map(&:"name_#{I18n.locale}").join(", ")
+    ]
+    row.concat survey_form.questions.map { |question| survey.survey_answers_for(question.id).value }
+    row.concat [survey.created_at, survey.quizzed_at]
+    row
+  end
+end

--- a/app/javascript/controllers/surveys_controller.js
+++ b/app/javascript/controllers/surveys_controller.js
@@ -1,0 +1,8 @@
+import { Controller } from "@hotwired/stimulus";
+import datePicker from "commons/filter_date_picker";
+
+export default class extends Controller {
+  connect() {
+    datePicker.init();
+  }
+}

--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -20,4 +20,15 @@ class Survey < ApplicationRecord
   has_many :survey_answers, dependent: :destroy
 
   accepts_nested_attributes_for :survey_answers, allow_destroy: true
+
+  def survey_answers_for(question_id)
+    survey_answers.find { |answer| answer.question_id == question_id }
+  end
+
+  def self.filter(params = {})
+    scope = all
+    scope = scope.where("created_at BETWEEN ? AND ?", DateTime.parse(params[:start_date]).beginning_of_day, DateTime.parse(params[:end_date]).end_of_day) if params[:start_date].present? && params[:end_date].present?
+    scope = scope.where(topic_id: params[:survey_form_id]) if params[:survey_form_id].present?
+    scope
+  end
 end

--- a/app/models/topics/survey_form.rb
+++ b/app/models/topics/survey_form.rb
@@ -19,7 +19,7 @@ module Topics
     # Association
     has_many :mobile_notifications, foreign_key: :topic_id
     has_many :questions, through: :sections
-    has_many :surveys, class_name: 'Survey', foreign_key: 'topic_id'
+    has_many :surveys, class_name: "Survey", foreign_key: "topic_id"
 
     # Validation
     validates_associated :sections

--- a/app/views/survey_forms/index.html.haml
+++ b/app/views/survey_forms/index.html.haml
@@ -39,7 +39,7 @@
             %td
               = link_to form.mobile_notifications.length, mobile_notifications_path(topic_id: form.id), class: 'text-primary' if form.mobile_notifications.length.positive?
             %td
-              = form.surveys.count if form.surveys.any?
+              = link_to form.surveys.count, survey_form_surveys_path(form), class: 'text-primary' if form.surveys.any?
             %td= form.tag_list
             %td= form.description
             %td= form_status_html(form).html_safe

--- a/app/views/survey_forms/surveys/index.html.haml
+++ b/app/views/survey_forms/surveys/index.html.haml
@@ -1,0 +1,53 @@
+.container-fluid.px-4{'data-controller' => 'surveys'}
+  -# Header
+  = render "shared/headers/page_heading", title: "#{t('form.survey')}: #{@survey_form.name}" do
+    = render "shared/buttons/back_button", url: survey_forms_path
+
+    %button.btn.btn-sm.ms-1{"aria-expanded" => "false", "data-bs-toggle" => "dropdown", :type => "button"}
+      %i.fa-solid.fa-ellipsis-vertical
+
+    %ul.dropdown-menu.dropdown-menu-end
+      - if current_user.primary_admin?
+        %li
+          %a.dropdown-item{ href: survey_form_surveys_path(@survey_form, filter_params.merge(format: :xlsx)), target: '_blank' }
+            %i.fa-regular.fa-file-excel
+            %span= t('shared.download_excel')
+
+          %a.dropdown-item{ href: survey_form_surveys_path(@survey_form, filter_params.merge(format: :csv)), target: '_blank' }
+            %i.fa-solid.fa-file-csv
+            %span= t('shared.download_csv')
+
+  -# Filters
+  .d-flex.mb-3
+    %form.flex-grow-1.d-flex{ action: survey_form_surveys_path(@survey_form), method: 'get'}
+      = render 'shared/filters/filter_date', placeholder: t('form.search_by_submitted_at')
+      .ms-2
+        = render "shared/buttons/search_button"
+
+  = render "shared/no_data", items: @surveys
+
+  - if @surveys.present?
+    .mt-2= render "shared/pagination_title", objects: @surveys
+
+    .table-responsive
+      %table.table.table-hover
+        %thead
+          %tr
+            %th #
+            - @survey_form.questions.each do |question|
+              %th{'data-bs-toggle' => 'tooltip', title: question.name }
+                = question.name[0..10]
+                - if question.name.length > 10
+                  %span{ title: question.name }= "..."
+
+            %th= t('form.quizzed_at')
+            %th= t('form.submitted_at')
+
+        %tbody
+          - @surveys.each_with_index do |survey, index|
+            %tr
+              %td= @pagy.from + index
+              - @survey_form.questions.each do |question|
+                %td= survey.survey_answers_for(question.id).value
+              %td= timeago(survey.quizzed_at, type: 'datetime').html_safe
+              %td= timeago(survey.created_at, type: 'datetime').html_safe

--- a/app/views/survey_forms/surveys/index.xlsx.axlsx
+++ b/app/views/survey_forms/surveys/index.xlsx.axlsx
@@ -1,0 +1,10 @@
+wb = xlsx_package.workbook
+worksheet_name = "survey_#{@survey_form.name}"[0..30]
+wb.add_worksheet(name: worksheet_name) do |sheet|
+  sheet.add_row build_survey_header(@survey_form)
+
+  @surveys.each do |survey|
+    row = build_survey_row(survey, @survey_form)
+    sheet.add_row row, types: row.length.times.map { |t| :string }
+  end
+end

--- a/config/locales/mobile_notification/en.yml
+++ b/config/locales/mobile_notification/en.yml
@@ -9,7 +9,7 @@ en:
     max_body: max 255 characters
     push_notification: Push Notification
     description: "Success: %{success_count}; Failure: %{failure_count}"
-    app_version: App version number
+    app_version: App version
     any_version: Any version
     versions_selected: versions selected
     all_version: All version

--- a/config/locales/shared/en.yml
+++ b/config/locales/shared/en.yml
@@ -107,3 +107,4 @@ en:
     confirm_to_copy: Confirm to copy %{name}
     are_you_sure_to_copy: Are you sure to copy the %{type} <b>%{name}</b>?
     copy_details: "This will copy all the details of this %{type} including: %{details}"
+    download_csv: Download CSV

--- a/config/locales/shared/km.yml
+++ b/config/locales/shared/km.yml
@@ -107,3 +107,4 @@ km:
     confirm_to_copy: បញ្ជាក់ការចម្លង %{name}
     are_you_sure_to_copy: តើអ្នកប្រាកដជាចម្លង %{type} <b>"%{name}"</b> នេះមែនទេ?
     copy_details: "ការចម្លងនេះនឹងចម្លងព័ត៌មានលម្អិតទាំងអស់នៃ %{type} នេះរួមមាន: %{details}"
+    download_csv: ទាញយកជា CSV

--- a/config/locales/topic/en.yml
+++ b/config/locales/topic/en.yml
@@ -52,3 +52,6 @@ en:
     add_question: + Add question
     option_icon_hint: The icon file(*.png, and 80px x 80px)
     number_of_participation: "# of participation"
+    quizzed_at: Quizzed at
+    submitted_at: Submitted at
+    search_by_submitted_at: Search by submitted at

--- a/config/locales/topic/km.yml
+++ b/config/locales/topic/km.yml
@@ -52,3 +52,6 @@ km:
     add_question: + បន្ថែមសំណួរ
     option_icon_hint: រូបតំណាង(*.png, and 80px x 80px)
     number_of_participation: "# ចំនួននៃការចូលរួម"
+    quizzed_at: កាលបរិច្ឆេទដែលបានស្ទង់មតិ
+    submitted_at: កាលបរិច្ឆេទដែលបានដាក់ស្នើ
+    search_by_submitted_at: ស្វែងរកដោយកាលបរិច្ឆេទដែលបានដាក់ស្នើ

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,6 +87,7 @@ Rails.application.routes.draw do
 
   resources :survey_forms do
     post :make_a_copy, on: :member
+    resources :surveys, only: [:index], module: :survey_forms
   end
 
   resources :reason_importers

--- a/lib/samples/survey.rb
+++ b/lib/samples/survey.rb
@@ -3,7 +3,7 @@ module Samples
     def load
       ::Survey.create(
         app_user:,
-        survey_form: survey_form,
+        topic_id: survey_form.id,
         quizzed_at: rand(1..5).days.ago,
         survey_answers_attributes:
       )
@@ -15,7 +15,7 @@ module Samples
       end
 
       def survey_form
-        @topic ||= ::Topics::SurveyForm.all.sample
+        @survey_form ||= ::Topics::SurveyForm.published.sample
       end
 
       def survey_answers_attributes

--- a/spec/models/survey_form_spec.rb
+++ b/spec/models/survey_form_spec.rb
@@ -5,14 +5,14 @@ RSpec.describe Topics::SurveyForm, type: :model do
   it { is_expected.to be_a(::Topic) }
 
   # Test Associations
-  describe 'associations' do
+  describe "associations" do
     it { is_expected.to have_many(:mobile_notifications).with_foreign_key(:topic_id) }
     it { is_expected.to have_many(:questions).through(:sections) }
-    it { is_expected.to have_many(:surveys).class_name('Survey').with_foreign_key(:topic_id) }
+    it { is_expected.to have_many(:surveys).class_name("Survey").with_foreign_key(:topic_id) }
   end
 
-  describe '.policy_class' do
-    it 'returns SurveyFormPolicy' do
+  describe ".policy_class" do
+    it "returns SurveyFormPolicy" do
       expect(described_class.policy_class).to eq(SurveyFormPolicy)
     end
   end

--- a/spec/models/survey_spec.rb
+++ b/spec/models/survey_spec.rb
@@ -13,7 +13,74 @@
 require "rails_helper"
 
 RSpec.describe Survey, type: :model do
-  it { is_expected.to belong_to(:app_user) }
-  it { is_expected.to belong_to(:topic) }
-  it { is_expected.to belong_to(:mobile_notification).optional }
+  describe "associations" do
+    it { should belong_to(:topic) }
+    it { should belong_to(:app_user) }
+    it { should belong_to(:mobile_notification).optional }
+    it { should have_many(:survey_answers).dependent(:destroy) }
+  end
+
+  describe "nested attributes" do
+    it { should accept_nested_attributes_for(:survey_answers).allow_destroy(true) }
+  end
+
+  describe "#survey_answers_for" do
+    let(:survey) { create(:survey) }
+    let(:question) { create(:question) }
+    let!(:survey_answer) { create(:survey_answer, survey:, question:) }
+
+    it "returns the survey answer for a given question_id" do
+      expect(survey.survey_answers_for(question.id)).to eq(survey_answer)
+    end
+
+    it "returns nil if no survey answer exists for the given question_id" do
+      expect(survey.survey_answers_for("nonexistent_id")).to be_nil
+    end
+  end
+
+  describe ".filter" do
+    let!(:survey1) { create(:survey, created_at: DateTime.parse("2025-05-01 12:00")) }
+    let!(:survey2) { create(:survey, created_at: DateTime.parse("2025-05-03 12:00"), topic: create(:topic)) }
+    let!(:survey3) { create(:survey, created_at: DateTime.parse("2025-05-05 12:00")) }
+
+    context "with start_date and end_date" do
+      let(:params) do
+        { start_date: "2025-05-01", end_date: "2025-05-03" }
+      end
+
+      it "returns surveys within the date range" do
+        expect(Survey.filter(params)).to include(survey1, survey2)
+        expect(Survey.filter(params)).not_to include(survey3)
+      end
+    end
+
+    context "with survey_form_id" do
+      let(:params) { { survey_form_id: survey2.topic_id } }
+
+      it "returns surveys with the specified topic_id" do
+        expect(Survey.filter(params)).to include(survey2)
+        expect(Survey.filter(params)).not_to include(survey1, survey3)
+      end
+    end
+
+    context "with no params" do
+      it "returns all surveys" do
+        expect(Survey.filter).to include(survey1, survey2, survey3)
+      end
+    end
+
+    context "with invalid date params" do
+      let(:params) { { start_date: "invalid", end_date: "2025-05-03" } }
+
+      it "raises an error for invalid dates" do
+        expect { Survey.filter(params) }.to raise_error(Date::Error)
+      end
+    end
+  end
+
+  describe "included concerns" do
+    it "includes Surveys::NotifiableConcern" do
+      expect(Survey.ancestors).to include(Surveys::NotifiableConcern)
+    end
+  end
 end


### PR DESCRIPTION
## What does this PR do?

- **Survey Form**:
  - Added a clickable link to display the number of participants, navigating to the survey list for the selected form.

- **Survey**:
  - Displays survey list with truncated titles and tooltips showing full titles.
  - Implemented date range filter for submission dates.
  - Enabled data download in Excel and CSV formats, with filters applied to submission dates.

## Screenshot
<img width="1506" alt="Screenshot 2025-05-08 at 10 40 40 AM" src="https://github.com/user-attachments/assets/d54a5891-d6fe-4a1d-9f41-75bf31b69e15" />
<img width="1508" alt="Screenshot 2025-05-08 at 10 44 19 AM" src="https://github.com/user-attachments/assets/c8996ab8-1949-4201-90f6-f83cb1caf349" />
<img width="1511" alt="Screenshot 2025-05-08 at 10 40 51 AM" src="https://github.com/user-attachments/assets/ba8ac2e6-f28b-40a4-a63e-58d99da3fcb1" />

<img width="1508" alt="Screenshot 2025-05-08 at 10 41 43 AM" src="https://github.com/user-attachments/assets/e12feb6d-81f2-45e0-88ef-d1c3258f2030" />
<img width="994" alt="Screenshot 2025-05-08 at 10 42 11 AM" src="https://github.com/user-attachments/assets/5a3ad9f1-b6be-43c5-b7dd-f6d307ce99b9" />

