### PR TITLE
Survey list: display and download answer as option name

### DIFF
--- a/app/controllers/survey_forms/surveys_controller.rb
+++ b/app/controllers/survey_forms/surveys_controller.rb
@@ -33,7 +33,7 @@ module SurveyForms
       end
 
       def query_surveys
-        authorize policy_scope(Survey.filter(filter_params).includes(:survey_answers))
+        authorize policy_scope(Survey.filter(filter_params).includes(survey_answers: :option))
       end
 
       def paginate_surveys

--- a/app/helpers/surveys_helper.rb
+++ b/app/helpers/surveys_helper.rb
@@ -21,13 +21,13 @@ module SurveysHelper
     row = [
       user.id[0..7],
       user.gender || "annonymous",
-      user.age,
+      (user.age unless user.anonymous?),
       (user.province["name_#{I18n.locale}"] unless user.anonymous?),
       t("app_user.#{user.occupation}"),
       t("app_user.#{user.education_level}"),
       user.characteristics.map(&:"name_#{I18n.locale}").join(", ")
     ]
-    row.concat survey_form.questions.map { |question| survey.survey_answers_for(question.id).value }
+    row.concat survey_form.questions.map { |question| survey.survey_answers_for(question.id).option_name }
     row.concat [survey.created_at, survey.quizzed_at]
     row
   end

--- a/app/models/survey_answer.rb
+++ b/app/models/survey_answer.rb
@@ -19,6 +19,8 @@ class SurveyAnswer < ApplicationRecord
   belongs_to :question
   belongs_to :option, optional: true
 
+  delegate :name, :value, to: :option, prefix: true, allow_nil: true
+
   # Callback
   after_create :notify_telegram_groups
 

--- a/app/views/survey_forms/surveys/index.html.haml
+++ b/app/views/survey_forms/surveys/index.html.haml
@@ -48,6 +48,6 @@
             %tr
               %td= @pagy.from + index
               - @survey_form.questions.each do |question|
-                %td= survey.survey_answers_for(question.id).value
+                %td= survey.survey_answers_for(question.id).option_name
               %td= timeago(survey.quizzed_at, type: 'datetime').html_safe
               %td= timeago(survey.created_at, type: 'datetime').html_safe

--- a/spec/models/survey_answer_spec.rb
+++ b/spec/models/survey_answer_spec.rb
@@ -15,5 +15,74 @@
 require "rails_helper"
 
 RSpec.describe SurveyAnswer, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "associations" do
+    it { is_expected.to belong_to(:survey).optional }
+    it { is_expected.to belong_to(:question) }
+    it { is_expected.to belong_to(:option).optional }
+  end
+
+  describe "uploader" do
+    it "mounts the AudioUploader for the voice attribute" do
+      expect(subject.class.uploaders[:voice]).to eq(AudioUploader)
+    end
+  end
+
+  describe "delegations" do
+    let(:option) { create(:option, name: "Option 1", value: "value1") }
+    let(:survey_answer) { create(:survey_answer, option:, question: option.question) }
+
+    it "delegates name to option with prefix" do
+      expect(survey_answer.option_name).to eq("Option 1")
+    end
+
+    it "delegates value to option with prefix" do
+      expect(survey_answer.option_value).to eq("value1")
+    end
+
+    context "when option is nil" do
+      let(:survey_answer) { create(:survey_answer, option: nil, question: create(:question)) }
+
+      it "returns nil for option_name" do
+        expect(survey_answer.option_name).to be_nil
+      end
+
+      it "returns nil for option_value" do
+        expect(survey_answer.option_value).to be_nil
+      end
+    end
+  end
+
+  describe "callbacks" do
+    describe "after_create :notify_telegram_groups" do
+      let(:survey) { create(:survey) }
+      let(:group1) { create(:chat_group) }
+      let(:group2) { create(:chat_group) }
+      let(:option) { create(:option, chat_groups: [group1, group2]) }
+      let(:survey_answer) { build(:survey_answer, survey:, option:, question: option.question) }
+
+      it "calls notify_groups_async on survey with option chat_groups" do
+        expect(survey).to receive(:notify_groups_async).with([group1, group2])
+        survey_answer.save
+      end
+
+      context "when option is nil" do
+        let(:survey_answer) { build(:survey_answer, survey:, option: nil, question: create(:question)) }
+
+        it "does not call notify_groups_async" do
+          expect(survey).not_to receive(:notify_groups_async)
+          survey_answer.save
+        end
+      end
+
+      context "when option has no chat_groups" do
+        let(:option) { create(:option, chat_groups: []) }
+        let(:survey_answer) { build(:survey_answer, survey:, option:, question: option.question) }
+
+        it "does not call notify_groups_async" do
+          expect(survey).not_to receive(:notify_groups_async)
+          survey_answer.save
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Why?
- Previously, survey answers were displayed as static values, which were difficult for users to understand.

## How?
- Modified the system to display and download survey answers as user-friendly option names.

## Screenshots
<img width="1506" alt="Screenshot 2025-05-08 at 5 30 07 PM" src="https://github.com/user-attachments/assets/16b44e8b-7c06-40b7-ab63-dbb6ebbacd5b" />
<img width="1506" alt="Screenshot 2025-05-09 at 5 36 22 AM" src="https://github.com/user-attachments/assets/02b2653f-648b-4b26-8a43-07b57b634e4e" />
<img width="1504" alt="Screenshot 2025-05-09 at 5 36 44 AM" src="https://github.com/user-attachments/assets/eee64dc0-370b-4250-8871-cdbec1ccc218" />
<img width="986" alt="Screenshot 2025-05-09 at 5 37 02 AM" src="https://github.com/user-attachments/assets/29cd8f93-a7e0-403b-8242-96b8073c08c9" />

