### PR TITLE
Survey: display total uniq user count and update download column title

### DIFF
--- a/app/controllers/survey_forms/surveys_controller.rb
+++ b/app/controllers/survey_forms/surveys_controller.rb
@@ -11,7 +11,10 @@ module SurveyForms
       @surveys = query_surveys
 
       respond_to do |format|
-        format.html { paginate_surveys }
+        format.html {
+          @total_uniq_users = Survey.filter(filter_params).pluck(:app_user_id).uniq.count
+          paginate_surveys
+        }
         format.xlsx {
           @surveys = @surveys.includes(app_user: :characteristics)
           export_xlsx

--- a/app/helpers/surveys_helper.rb
+++ b/app/helpers/surveys_helper.rb
@@ -10,9 +10,9 @@ module SurveysHelper
   end
 
   def build_survey_header(survey_form)
-    user_headers = %w[_id _gender _age _province _occupation _education_level _characteristic]
+    user_headers = %w[id gender age province occupation educationlevel characteristic]
     question_headers = survey_form.questions.map(&:name)
-    time_headers = %w[_submission_time _quizzed_time]
+    time_headers = %w[submission_time quizzed_time]
     user_headers + question_headers + time_headers
   end
 

--- a/app/views/shared/_pagination_title.html.haml
+++ b/app/views/shared/_pagination_title.html.haml
@@ -5,7 +5,7 @@
         .flex-1.d-flex.align-items-center.mb-2
           %span
             = t('shared.pagination_title', from: @pagy.from, to: @pagy.to, total: number_with_delimiter(@pagy.count)).html_safe
-
+            = yield if block_given?
   .flex-grow-1
 
   - if @pagy.pages > 1

--- a/app/views/survey_forms/index.html.haml
+++ b/app/views/survey_forms/index.html.haml
@@ -14,7 +14,7 @@
   = render "shared/no_data", items: @forms
 
   - if @forms.present?
-    .mt-2= render "shared/pagination_title", objects: @forms
+    .mt-3= render "shared/pagination_title", objects: @forms
 
     %table.table.table-hover
       %thead

--- a/app/views/survey_forms/surveys/index.html.haml
+++ b/app/views/survey_forms/surveys/index.html.haml
@@ -27,7 +27,9 @@
   = render "shared/no_data", items: @surveys
 
   - if @surveys.present?
-    .mt-2= render "shared/pagination_title", objects: @surveys
+    .mt-2
+      = render "shared/pagination_title", objects: @surveys do
+        %span= "(#{t('form.total_unique_users')}: <b>#{number_with_delimiter(@total_uniq_users)}</b>)".html_safe
 
     .table-responsive
       %table.table.table-hover

--- a/config/locales/topic/en.yml
+++ b/config/locales/topic/en.yml
@@ -55,3 +55,4 @@ en:
     quizzed_at: Quizzed at
     submitted_at: Submitted at
     search_by_submitted_at: Search by submitted at
+    total_unique_users: Total unique users

--- a/config/locales/topic/km.yml
+++ b/config/locales/topic/km.yml
@@ -55,3 +55,4 @@ km:
     quizzed_at: កាលបរិច្ឆេទដែលបានស្ទង់មតិ
     submitted_at: កាលបរិច្ឆេទដែលបានដាក់ស្នើ
     search_by_submitted_at: ស្វែងរកដោយកាលបរិច្ឆេទដែលបានដាក់ស្នើ
+    total_unique_users: ចំនួនអ្នកចូលរួមសរុប


### PR DESCRIPTION
## What does this PR do?
- Display total unique users near the pagination info
- Update the title for the Excel and CSV format by removing the underscore for each column

## Screenshots
<img width="1508" alt="Screenshot 2025-05-09 at 1 04 38 PM" src="https://github.com/user-attachments/assets/7e415d52-ed9e-4ef4-aefa-4d201eb3ae49" />

<img width="872" alt="Screenshot 2025-05-09 at 1 01 02 PM" src="https://github.com/user-attachments/assets/69d60483-412a-4666-a018-829d749e6540" />
