### PR TITLE
add pull request template file

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Why:
+
+## How:
+
+## Migration/Rake/Task:
+
+## Screenshots:
+
+## The pull request is good to be merged when:
+- [ ] No typos and correct grammar
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] New and existing unit tests pass on CI with my changes


### PR DESCRIPTION
## Why
- Implement a default Pull Request (PR) template to standardize PR descriptions. This ensures contributors clearly specify the purpose, solution, screenshots, and any migration or rake tasks, facilitating better reviews and collaboration.

## How
- Add a `PULL_REQUEST_TEMPLATE.md` file in the `.github/` directory.
- GitHub will automatically populate the PR description with the template's content when a contributor creates a new PR.
